### PR TITLE
Fix #12 Externalize bash scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 ```
 $ git clone https://github.com/LalatenduMohanty/centos-live-iso.git
 $ cd centos-live-iso
-$ livecd-creator --config ./centos-7-minimal.ks --fslabel live-centos
+$ ./create_live_iso
 ```
 
 <a name="on-hosts-without-livecd-tools-os-x-windows-"></a>
@@ -56,7 +56,7 @@ $ cd centos-live-iso
 $ vagrant up
 $ vagrant ssh
 $ cd <path to centos-live-iso directory on the VM>/centos-live-iso
-$ sudo livecd-creator --config ./centos-7-minimal.ks --fslabel live-centos
+$ sudo ./create_live_iso
 ```
 
 <a name="further-reading"></a>

--- a/centos-7-minimal.template
+++ b/centos-7-minimal.template
@@ -20,8 +20,6 @@ repo --name=base --baseurl=http://mirror.centos.org/centos/7/os/x86_64/
 repo --name=updates --baseurl=http://mirror.centos.org/centos/7/updates/x86_64/
 repo --name=extras --baseurl=http://mirror.centos.org/centos/7/extras/x86_64/
 
-user --name=docker --password=tcuser
-
 shutdown
 
 %packages  --excludedocs --instLangs=en
@@ -74,46 +72,21 @@ syslinux
 # Setting a global Locale for the server
 echo "LANG=\"C\"" > /etc/locale.conf
 
-# sudo permission
+# Add docker user with 'tcuser' password
+/usr/sbin/useradd -p '$1$AhiE7wa5$d8puTTTSvN7Hq3JgUvfLV/' docker
+/usr/sbin/usermod -a -G docker docker
+
+# sudo permission for docker user
 echo "%docker ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/docker
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
 
-cat > /etc/rc.d/init.d/handle-user-data << EOF
-#!/bin/sh
-LABEL=boot2docker-data
-MAGIC="boot2docker, please format-me"
-
-# TODO Why can I not generate the docker user outside of this init script as part
-# of the kickstart file?
-# https://github.com/LalatenduMohanty/centos-live-iso/issues/10
-useradd -p tcuser docker
-groupadd docker
-usermod -a -G docker docker
-
-# TODO Need to make sure to have /sbin on the PATH. Is there a better way?
-# http://stackoverflow.com/questions/19983710/some-commands-not-wroking-on-remote-servers-through-ssh-shell
-# https://github.com/LalatenduMohanty/centos-live-iso/issues/11
-echo 'PATH=$PATH:/sbin' >> /home/docker/.bashrc
-
-# If there is a partition with `boot2docker-data` as its label we are dealing with
-# an already bootstrapped docker-machine.
-BOOT2DOCKER_DATA=`blkid -o device -l -t LABEL=$LABEL`
-if [ -n "$BOOT2DOCKER_DATA" ]; then
-	exit 0
-fi
-
-# Test for our magic string (it means that the disk was made by ./boot2docker init)
-HEADER=`dd if=/dev/sda bs=1 count=${#MAGIC} 2>/dev/null`
-
-if [ "$HEADER" = "$MAGIC" ]; then
-	# Read /userdata.tar with ssh keys
-	# TODO we need to add checks whether the userdata.tar is still there or whether
-	# the disk got already formatted
-	dd if=/dev/sda of=/userdata.tar bs=1 count=4096 2>/dev/null
-	tar xf /userdata.tar -C /home/docker/ > /var/log/userdata.log 2>&1
-	chown -R docker:docker /home/docker/.ssh
-fi
+# Place holder for base64 encrypt handle-user-data script
+cat > handle-user-data.base64 << EOF
+${handle_user_data}
 EOF
+
+base64 -d < handle-user-data.base64 > handle-user-data
+mv handle-user-data /etc/rc.d/init.d/
 
 chmod +x /etc/rc.d/init.d/handle-user-data
 /sbin/restorecon /etc/rc.d/init.d/handle-user-data

--- a/create_live_iso
+++ b/create_live_iso
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# you can specify any addition file same way and make a entry to template
+export handle_user_data=`base64 -w 0 handle-user-data`
+
+#sed -i.back "/^cat > handle-user-data.base64 << EOF/{s/.*/&\n$bas64_str/;:a;n;ba}" centos-7-minimal.ks
+
+kickstart_file="centos-7-minimal.ks"
+
+if [ -f "$kickstart_file" ] ; then
+    rm $kickstart_file
+fi
+
+touch $kickstart_file
+
+envsubst < centos-7-minimal.template > centos-7-minimal.ks
+
+livecd-creator --config ./centos-7-minimal.ks --fslabel live-centos

--- a/handle-user-data
+++ b/handle-user-data
@@ -1,0 +1,27 @@
+#!/bin/sh
+LABEL=boot2docker-data
+MAGIC="boot2docker, please format-me"
+
+# TODO Need to make sure to have /sbin on the PATH. Is there a better way?
+# http://stackoverflow.com/questions/19983710/some-commands-not-wroking-on-remote-servers-through-ssh-shell
+# https://github.com/LalatenduMohanty/centos-live-iso/issues/11
+echo 'PATH=$PATH:/sbin' >> /home/docker/.bashrc
+
+# If there is a partition with `boot2docker-data` as its label we are dealing with
+# an already bootstrapped docker-machine.
+BOOT2DOCKER_DATA=`blkid -o device -l -t LABEL=$LABEL`
+if [ -n "$BOOT2DOCKER_DATA" ]; then
+    exit 0
+fi
+
+# Test for our magic string (it means that the disk was made by ./boot2docker init)
+HEADER=`dd if=/dev/sda bs=1 count=${#MAGIC} 2>/dev/null`
+
+if [ "$HEADER" = "$MAGIC" ]; then
+    # Read /userdata.tar with ssh keys
+    # TODO we need to add checks whether the userdata.tar is still there or whether
+    # the disk got already formatted
+    dd if=/dev/sda of=/userdata.tar bs=1 count=4096 2>/dev/null
+    tar xf /userdata.tar -C /home/docker/ > /var/log/userdata.log 2>&1
+    chown -R docker:docker /home/docker/.ssh
+fi


### PR DESCRIPTION
This patch is use to externalize bash script from kickstart so that it will be easy to develop and test.